### PR TITLE
Convert json to classes, other perf improvements

### DIFF
--- a/Time of Territory/Assets/SimpleJSON.cs
+++ b/Time of Territory/Assets/SimpleJSON.cs
@@ -1,4 +1,4 @@
-﻿/* * * * *
+/* * * * *
  * A simple JSON Parser / builder
  * ------------------------------
  * 
@@ -895,8 +895,8 @@ namespace SimpleJSON
         {
             get
             {
-                if (m_Dict.ContainsKey(aKey))
-                    return m_Dict[aKey];
+                if (m_Dict.TryGetValue(aKey, out var result))
+                    return result;
                 else
                     return new JSONLazyCreator(this, aKey);
             }
@@ -1003,6 +1003,10 @@ namespace SimpleJSON
                 foreach (KeyValuePair<string, JSONNode> N in m_Dict)
                     yield return N.Value;
             }
+        }
+
+        public Dictionary<string, JSONNode>.KeyCollection GetKeys() {
+            return m_Dict.Keys;
         }
 
         internal override void WriteToStringBuilder(StringBuilder aSB, int aIndent, int aIndentInc, JSONTextMode aMode)

--- a/Time of Territory/Assets/TRenderer.cs
+++ b/Time of Territory/Assets/TRenderer.cs
@@ -758,6 +758,10 @@ public class TRenderer : MonoBehaviour
             // 1) Don't go too fast (too many states could fill up memory)
             // 2) quit once we are at the max tick
             // 3) (TODO) In the Unity editor, when the game is played and closed, this thread will keep going. Dunno how to fix this
+            // 4) (TODO) Bug: If animating outpaces the bg thread, then the tick will increment in the UI while none of the units do
+            //    anything. So tick 77 in the json files might only happen at tick 151 or something in the viewed game. Does not seem
+            //    to be much of a problem when the game is compiled and run outside of Unity, especially when animating the units takes
+            //    time (i.e. maybe we have dozens of units on-screen).
             var currentTick = startTick;
             var maxStates = 20;
             while (currentTick < maxTick)


### PR DESCRIPTION
Changelog
- convert Json models to our own class models in background thread
- fix tick + 1 bug (game starts at 0, then bg thread loads tick 0 so it is shown twice in a row)
- some SimpleJSON improvements/ease of use by the renderer script
- use chars instead of strings where feasible
- cache the HPbar instead of having to look it up each time (50ms performance difference in deep profile)
- Reduce some lookups ie dictionary and game object name lookups